### PR TITLE
added proper support for svg in gulpfile + fix bug when opening sub-header

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -198,7 +198,7 @@ gulp.task('watch', ['connect', 'default'], function () {
     }
   });
   gulp.watch('./index.html', ['index']);
-  gulp.watch(['./templates/**/*.html'], ['templates']);
+  gulp.watch(['./templates/**/*.html', './templates/**/*.svg'], ['templates']);
   gulp.watch(['./scss/**/*.scss']).on('change', function (evt) {
     if (evt.type !== 'changed') {
       gulp.start('index');
@@ -285,7 +285,7 @@ function appFiles () {
  * All AngularJS templates/partials as a stream
  */
 function templateFiles (opt) {
-  return gulp.src(['./templates/**/*.html'], opt)
+  return gulp.src(['./templates/**/*.html', './templates/**/*.svg'], opt)
     .pipe(opt && opt.min ? g.htmlmin(htmlminOpts) : noop());
 }
 

--- a/js/modules/main/src/services/headerService.js
+++ b/js/modules/main/src/services/headerService.js
@@ -16,6 +16,7 @@ angular.module('main').
 		            _sub_header_state = 'closed';
 		        }
 		        else {
+		            window.scroll(0, 0);
 		            _sub_header_state = new_state;
 				}
 			},


### PR DESCRIPTION
* fixed the bug in #314 - by adding proper support for svg files in gulpfile
* fixed a bug in sub-header:
  * **reproduction steps**: scroll the page down, then click on search or recently viewed in header
    * *expected*: show the search / recently sub-header
    * *actual*: doesn't show the sub-header (if you scroll back up you will see it)
  * fixed by scrolling back to top of the page when opening the sub-header
    * it's a bit hackish but it works.. I don't think it's worth to invest in a proper solution