### PR TITLE
#322 Fix to image title on homepage

### DIFF
--- a/templates/main/start.html
+++ b/templates/main/start.html
@@ -26,7 +26,7 @@
 
     <div class="caption">
       <span class="caption__text">
-        <en>Image Details: <a ui-sref="item-view ({collection: 'image', local_slug: 'girls-soldiers-standing-on-a-truck-israel-1950s'})">Girls soldiers standing on a truck, Israel 1950s.</a></en>
+        <en>Image Details: <a ui-sref="item-view ({collection: 'image', local_slug: 'girls-soldiers-standing-on-a-truck-israel-1950s'})">Female soldiers standing on a truck, Israel 1950s.</a></en>
         <he>פרטי התמונה: <a ui-sref="he.he_item-view ({collection: 'תמונה', local_slug: 'חיילות-עומדות-על-משאית-ישראל-1950-בקירוב'})">חיילות עומדות על משאית, ישראל 1950 בקירוב.</a></he>
       </span>
     </div>


### PR DESCRIPTION
The name for this title was generated from a slug. The title changed in BHP and on item page, but Slugs dont change, ever. This change manually fixes the title of the link leading to the item page to be in line with the item page's title.