### PR TITLE
display General Search Suggestions

### DIFF
--- a/js/modules/main/src/controllers/subHeaderController.js
+++ b/js/modules/main/src/controllers/subHeaderController.js
@@ -1,18 +1,169 @@
-var SubHeaderController = function($state, header) {
+var SubHeaderController = function($state, header, suggest, $timeout) {
 
     this.$state = $state;
     this.header = header;
+    this.suggest = suggest;
+    this.$timeout = $timeout;
+    this.suggested = {};
+
+    this.suggested_open = {
+        general: false
+    };
+
+    this.suggested_index = {
+        general: -1
+    };
+
+    Object.defineProperty(this, 'raw_suggested', {
+        get: function() {
+
+            return suggest.suggested;
+        }
+    });
+
+    Object.defineProperty(this, 'suggested_distribution', {
+        get: function() {
+            return {
+                general: [
+                    suggest.suggested.general.exact.length,
+                    suggest.suggested.general.starts_with.length,
+                    suggest.suggested.general.contains.length,
+                    suggest.suggested.general.phonetic.length
+                ]
+            }
+        }
+    });
+
+    Object.defineProperty(this.suggested, 'general', {
+        get: function() {
+            return suggest.suggested.general.exact.
+                concat(suggest.suggested.general.starts_with.
+                    concat(suggest.suggested.general.contains.
+                        concat(suggest.suggested.general.phonetic)
+                    )
+                );
+        }
+    });
 };
 
 SubHeaderController.prototype = {
+
+    get_suggestions: function(type) {
+        var promise,
+            self = this;
+
+        this.suggested_index[type] = -1;
+
+        if (this.header.query) {
+            promise = this.suggest.suggest_general(this.header.query);
+
+            promise.
+                then(function() {
+                    if (self.suggested[type].length > 0) {
+                        self.open_suggested(type);
+                    }
+                    else {
+                        self.close_suggested(type);
+                    }
+                });
+        }
+        else {
+            this.close_suggested(type);
+        }
+    },
+
+
+    open_suggested: function(type) {
+        if ( this.suggested[type].length > 0 && this.header.query ) {
+            this.suggested_open[type] = true;
+
+        }
+    },
+
+    close_suggested: function(type) {
+        var self = this;
+
+        this.$timeout(function() {
+            self.suggested_open[type] = false;
+        }, 200);
+    },
+
+    isSelectedSuggested: function(type, value) {
+        return this.suggested[type].indexOf(value) === this.suggested_index[type];
+    },
+
+    get_active_title: function(type) {
+        if (this.suggested_index[type] >= this.suggested_distribution[type][0]) {
+            if (this.suggested_index[type] >= this.suggested_distribution[type][0] + this.suggested_distribution[type][1] + this.suggested_distribution[type][2]) {
+                return 3;
+            }
+            if (this.suggested_index[type] >= this.suggested_distribution[type] + this.suggested_distribution[type][1]) {
+                return 2;
+            }
+            else {
+                return 1;
+            }
+        }
+        else {
+            return 0;
+        }
+    },
+    select_suggested: function(type, value) {
+        this.suggested_index[type] = this.suggested[type].indexOf(value);
+    },
+
+    adopt: function(type) {
+        this.header.query = this.suggested.general[this.suggested_index.general];
+        this.$state.go('general-search', {q: this.header.query});
+    },
+
+    handle_keyboard: function($event, type) {
+        var suggested_count = this.suggested[type].length;
+
+        if ( !this.suggested_open[type] ) {
+            return true;
+        }
+
+        if (suggested_count > 0) {
+            if($event.keyCode === 40) {
+                $event.preventDefault();
+
+                if (this.suggested_index[type] === suggested_count - 1) {
+                    this.suggested_index[type] = 0;
+                }
+                else {
+                    this.suggested_index[type] +=1 ;
+                }
+            }
+            else if ($event.keyCode === 38) {
+                $event.preventDefault();
+
+                if (this.suggested_index[type] === 0 || this.suggested_index[type] === -1) {
+                    this.suggested_index[type] = suggested_count - 1;
+                }
+                else {
+                    this.suggested_index[type] -=1 ;
+                }
+            }
+            else if ($event.keyCode === 13) {
+                if (this.suggested[type][ this.suggested_index[type] ]) {
+                    $event.preventDefault();
+                    this.adopt(type);
+                }
+
+                this.close_suggested(type);
+            }
+        }
+    },
+
     search: function() {
         this.$state.go('general-search', {q: this.header.query});
     },
-    
+
     search_on_enter:function ($event) {
         if ($event.keyCode === 13 && this.header.query.length > 1)
             this.search();
     }
 };
 
-angular.module('main').controller('SubHeaderController', ['$state', 'header', SubHeaderController]);
+angular.module('main').controller('SubHeaderController', ['$state', 'header', 'suggest', '$timeout', SubHeaderController]);

--- a/js/modules/main/src/controllers/subHeaderController.js
+++ b/js/modules/main/src/controllers/subHeaderController.js
@@ -16,7 +16,6 @@ var SubHeaderController = function($state, header, suggest, $timeout) {
 
     Object.defineProperty(this, 'raw_suggested', {
         get: function() {
-
             return suggest.suggested;
         }
     });
@@ -25,10 +24,9 @@ var SubHeaderController = function($state, header, suggest, $timeout) {
         get: function() {
             return {
                 general: [
-                    suggest.suggested.general.exact.length,
-                    suggest.suggested.general.starts_with.length,
-                    suggest.suggested.general.contains.length,
-                    suggest.suggested.general.phonetic.length
+                    suggest.suggested.general.People.length,
+                    suggest.suggested.general.Articles.length,
+                    suggest.suggested.general.Media.length
                 ]
             }
         }
@@ -36,12 +34,9 @@ var SubHeaderController = function($state, header, suggest, $timeout) {
 
     Object.defineProperty(this.suggested, 'general', {
         get: function() {
-            return suggest.suggested.general.exact.
-                concat(suggest.suggested.general.starts_with.
-                    concat(suggest.suggested.general.contains.
-                        concat(suggest.suggested.general.phonetic)
-                    )
-                );
+            return suggest.suggested.general.People.
+                concat(suggest.suggested.general.Articles.
+                    concat(suggest.suggested.general.Media));
         }
     });
 };
@@ -51,7 +46,6 @@ SubHeaderController.prototype = {
     get_suggestions: function(type) {
         var promise,
             self = this;
-
         this.suggested_index[type] = -1;
 
         if (this.header.query) {
@@ -74,9 +68,8 @@ SubHeaderController.prototype = {
 
 
     open_suggested: function(type) {
-        if ( this.suggested[type].length > 0 && this.header.query ) {
+        if (this.suggested[type].length > 0 && this.header.query) {
             this.suggested_open[type] = true;
-
         }
     },
 
@@ -108,11 +101,11 @@ SubHeaderController.prototype = {
             return 0;
         }
     },
-    select_suggested: function(type, value) {
+    select_suggested: function(type, collection, value) {
         this.suggested_index[type] = this.suggested[type].indexOf(value);
     },
 
-    adopt: function(type) {
+    adopt: function() {
         this.header.query = this.suggested.general[this.suggested_index.general];
         this.$state.go('general-search', {q: this.header.query});
     },
@@ -148,7 +141,7 @@ SubHeaderController.prototype = {
             else if ($event.keyCode === 13) {
                 if (this.suggested[type][ this.suggested_index[type] ]) {
                     $event.preventDefault();
-                    this.adopt(type);
+                    this.adopt();
                 }
 
                 this.close_suggested(type);

--- a/js/modules/main/src/services/suggestService.js
+++ b/js/modules/main/src/services/suggestService.js
@@ -33,10 +33,9 @@ angular.module('main').
 					phonetic: []
 				},
 				general: {
-					exact: [],
-					starts_with: [],
-					contains: [],
-					phonetic: []
+					Articles: [],
+					People: [],
+					Media: []
 				}
 			},
 
@@ -57,8 +56,8 @@ angular.module('main').
 				var count, exact, all_suggestions;
 				var value_lc = value.toLowerCase();
 
-				return $http.get(apiClient.urls.suggest + '/' + collection_name_map[what] + '/' + value).
-					success(function(response) {
+				return $http.get(apiClient.urls.suggest + '/' + collection_name_map[what] + '/' + value)
+					.success(function(response) {
 						suggest.suggested = {
 							names: {
 								exact: [],
@@ -72,40 +71,45 @@ angular.module('main').
 								contains: [],
 								phonetic: []
 							},
-							general: {
-								exact: [],
-								starts_with: [],
-								contains: [],
-								phonetic: []
-							}
+							general: {}
 						};
-						exact = null;
-						all_suggestions = [];
 
-						['starts_with', 'contains', 'phonetic'].forEach(function(group) {
-							if (what == 'general') {
-								for (var collection in response[group]) {
-									for(var i=0; i<response[group][collection].length; i++) {
-										var suggestion = response[group][collection][i];
-
-								    	if (suggestion.toLowerCase() === value_lc) {
-											exact = suggestion;
-										}
-										else {
-											all_suggestions	= suggest.suggested[what].starts_with.
-												concat(suggest.suggested[what].contains.
-													concat(suggest.suggested[what].phonetic)
-												);
-
-											if (all_suggestions.indexOf(suggestion) === -1) {
-												suggest.suggested[what][group].push(suggestion);
-											}
-										}
+						if (what == 'general') {
+							var sections = {'Articles': [], 'People': [], 'Media': []};
+							for (var collection in response.starts_with) {
+								for(var i=0; i<response.starts_with[collection].length; i++) {
+									var suggestion = response.starts_with[collection][i];
+									// collection == "familyNames"
+									// suggestion == "Hoch"
+									if (["familyNames", "places"].indexOf(collection) > -1) {
+										sections["Articles"].push(suggestion);
+									} else if (["persons", "personalities"].indexOf(collection) > -1) {
+										sections["People"].push(suggestion);
+									} else if (["photoUnits", "movies"].indexOf(collection) > -1) {
+										sections["Media"].push(suggestion);
 									}
 								}
-
 							}
-							else {
+
+							Object.keys(sections).forEach(function(section) {
+									sections[section].sort();
+									//remove duplicates
+									var sorted_arr = [];
+									for (var i = 0; i < sections[section].length - 1; i++) {
+									    if (sections[section][i + 1] !== sections[section][i]) {
+									        sorted_arr.push(sections[section][i]);
+									    }
+									}
+									//return no more than 6 results
+									sections[section] = sorted_arr.slice(0, 6);
+							})
+
+							suggest.suggested[what] = sections;
+						}
+						else {
+							exact = null;
+							all_suggestions = [];
+							['starts_with', 'contains', 'phonetic'].forEach(function(group) {
 								response[group].forEach(function(suggestion) {
 									if (suggestion.toLowerCase() === value_lc) {
 											exact = suggestion;
@@ -121,14 +125,14 @@ angular.module('main').
 										}
 									}
 								})
+							});
+							if (exact) {
+								suggest.suggested[what].exact.push(exact);
 							}
-						});
+						};
 
-						if (exact) {
-							suggest.suggested[what].exact.push(exact);
-						}
-					}).
-					error(function() {
+					})
+					.error(function() {
 						suggest.failed = true;
 					}).
 					finally(function() {

--- a/js/modules/main/src/services/suggestService.js
+++ b/js/modules/main/src/services/suggestService.js
@@ -82,28 +82,25 @@ angular.module('main').
 									// collection == "familyNames"
 									// suggestion == "Hoch"
 									if (["familyNames", "places"].indexOf(collection) > -1) {
-										sections["Articles"].push(suggestion);
+										if (sections["Articles"].indexOf(suggestion) == -1) {
+											sections["Articles"].push(suggestion);
+										}
 									} else if (["persons", "personalities"].indexOf(collection) > -1) {
-										sections["People"].push(suggestion);
+										if (sections["People"].indexOf(suggestion) == -1) {
+											sections["People"].push(suggestion);
+										}
 									} else if (["photoUnits", "movies"].indexOf(collection) > -1) {
-										sections["Media"].push(suggestion);
+										if (sections["Media"].indexOf(suggestion) == -1) {
+											sections["Media"].push(suggestion);
+										}
 									}
 								}
 							}
 
 							Object.keys(sections).forEach(function(section) {
-									sections[section].sort();
-									//remove duplicates
-									var sorted_arr = [];
-									for (var i = 0; i < sections[section].length - 1; i++) {
-									    if (sections[section][i + 1] !== sections[section][i]) {
-									        sorted_arr.push(sections[section][i]);
-									    }
-									}
-									//return no more than 6 results
-									sections[section] = sorted_arr.slice(0, 6);
-							})
-
+								//sort and remove duplicates
+								sections[section] = sections[section].sort().slice(0, 6);
+							});
 							suggest.suggested[what] = sections;
 						}
 						else {

--- a/js/modules/main/src/services/suggestService.js
+++ b/js/modules/main/src/services/suggestService.js
@@ -11,7 +11,8 @@ angular.module('main').
 
 		var collection_name_map = {
 			names: 'familyNames',
-			places: 'places'
+			places: 'places',
+			general: '*'
 		},
 
 		suggest = {
@@ -30,6 +31,12 @@ angular.module('main').
 					starts_with: [],
 					contains: [],
 					phonetic: []
+				},
+				general: {
+					exact: [],
+					starts_with: [],
+					contains: [],
+					phonetic: []
 				}
 			},
 
@@ -39,6 +46,9 @@ angular.module('main').
 
 			suggest_places: function(place) {
 				return get_suggestions('places', place);
+			},
+			suggest_general: function(query) {
+				return get_suggestions('general', query);
 			}
 		};
 
@@ -61,26 +71,57 @@ angular.module('main').
 								starts_with: [],
 								contains: [],
 								phonetic: []
+							},
+							general: {
+								exact: [],
+								starts_with: [],
+								contains: [],
+								phonetic: []
 							}
 						};
 						exact = null;
 						all_suggestions = [];
 
 						['starts_with', 'contains', 'phonetic'].forEach(function(group) {
-							response[group].forEach(function(suggestion) {
-								if (suggestion.toLowerCase() === value_lc) {
-									exact = suggestion;
-								}
-								else {
-									all_suggestions	= suggest.suggested[what].starts_with.
-										concat(suggest.suggested[what].contains.
-											concat(suggest.suggested[what].phonetic)
-										);
-									if (all_suggestions.indexOf(suggestion) === -1) {
-										suggest.suggested[what][group].push(suggestion);
+							if (what == 'general') {
+								for (var collection in response[group]) {
+									for(var i=0; i<response[group][collection].length; i++) {
+										var suggestion = response[group][collection][i];
+
+								    	if (suggestion.toLowerCase() === value_lc) {
+											exact = suggestion;
+										}
+										else {
+											all_suggestions	= suggest.suggested[what].starts_with.
+												concat(suggest.suggested[what].contains.
+													concat(suggest.suggested[what].phonetic)
+												);
+
+											if (all_suggestions.indexOf(suggestion) === -1) {
+												suggest.suggested[what][group].push(suggestion);
+											}
+										}
 									}
 								}
-							});
+
+							}
+							else {
+								response[group].forEach(function(suggestion) {
+									if (suggestion.toLowerCase() === value_lc) {
+											exact = suggestion;
+									}
+									else {
+										all_suggestions	= suggest.suggested[what].starts_with.
+											concat(suggest.suggested[what].contains.
+												concat(suggest.suggested[what].phonetic)
+											);
+
+										if (all_suggestions.indexOf(suggestion) === -1) {
+											suggest.suggested[what][group].push(suggestion);
+										}
+									}
+								})
+							}
 						});
 
 						if (exact) {

--- a/scss/main/_sub-header.scss
+++ b/scss/main/_sub-header.scss
@@ -72,7 +72,7 @@
 }
 .sub-header-container {
 	position: relative;
-	z-index: 1;
+	z-index: 2;
 	height: 74px;
 	width: 100%;
 	margin-top: -74px;

--- a/scss/main/_wizard-form.scss
+++ b/scss/main/_wizard-form.scss
@@ -82,6 +82,9 @@
               width: 100%;
               padding: 0 33px;
               margin: 0 auto;
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
               @include hover_pointer();
 
               &--selected {

--- a/templates/main/sub-header.html
+++ b/templates/main/sub-header.html
@@ -12,55 +12,67 @@
 			        	<he>חיפוש כללי: </he>
 			    	</label>
 			    	<div class="gsearch-box-wrapper">
-				    	<input  id="search-input"
-				    			ng-model="subHeaderCtrl.header.query"
-				    			autofocus
+              <input  id="search-input"
+                  ng-model="subHeaderCtrl.header.query"
+                  autofocus
                   ng-change="subHeaderCtrl.get_suggestions('general')"
                   ng-focus="subHeaderCtrl.open_suggested('general')"
                   ng-blur="subHeaderCtrl.close_suggested('general')"
-
                   ng-keydown="subHeaderCtrl.handle_keyboard($event, 'general')"
-				    			type="text"
-				    			placeholder="{{(lang=='en')?'Continue to explore...':'להמשיך לחקור...'}}">
+                  type="text"
+                  placeholder="{{(lang=='en')?'Continue to explore...':'להמשיך לחקור...'}}">
+
               <div class="wizard-form__field__autosuggest-wrapper">
                 <div class="wizard-form__field__autosuggest-wrapper__autosuggest" ng-show="subHeaderCtrl.suggested_open['general']">
                   <div class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper">
-
-                    <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type"
-                        ng-show="subHeaderCtrl.suggested_distribution.general[0] > 0">
-                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title"
-                          ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title--selected': subHeaderCtrl.get_active_title('general') === 0}">
-                          <en>Exact Match:</en>
-                          <he>התאמה מלאה:</he>
-                      </div>
-                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item"
-                          ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item--selected': subHeaderCtrl.isSelectedSuggested('general', suggested)}"
-                          ng-click="subHeaderCtrl.adopt('name')"
-                          ng-mouseover="subHeaderCtrl.select_suggested('general', suggested)"
-                          ng-repeat="suggested in subHeaderCtrl.raw_suggested.general.exact track by $index">
-                          {{suggested}}
-                      </div>
-                    </div>
-
-
-                    <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type"
-                        ng-show="subHeaderCtrl.suggested_distribution.general[1] > 0">
-                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title"
-                          ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title--selected': subHeaderCtrl.get_active_title('general') === 1}">
-                          <en>Starts With:</en>
+                    <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type" ng-show="subHeaderCtrl.suggested_distribution.general[0] > 0">
+                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title">
+                          <en>People:</en>
                           <he>מתחיל מ:</he>
                       </div>
                       <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item"
-                          ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item--selected': subHeaderCtrl.isSelectedSuggested('general', suggested)}"
-                          ng-click="subHeaderCtrl.adopt('general')"
-                          ng-mouseover="subHeaderCtrl.select_suggested('general', suggested)"
-                          ng-repeat="suggested in subHeaderCtrl.raw_suggested.general.starts_with | limitTo: 5 track by $index">
+                            ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item--selected': subHeaderCtrl.isSelectedSuggested('general', suggested)}"
+                            ng-click="subHeaderCtrl.adopt('general', 'People')"
+                            ng-repeat="suggested in subHeaderCtrl.raw_suggested.general.People"
+                            ng-mouseover="subHeaderCtrl.select_suggested('general', 'People', suggested)">
                           {{suggested}}
                       </div>
                     </div>
+
+                    <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type" ng-show="subHeaderCtrl.suggested_distribution.general[1] > 0">
+                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title" ng-show="subHeaderCtrl.raw_suggested.general.Articles.length > 0">
+                          <en>Articles:</en>
+                          <he>מתחיל מ:</he>
+                      </div>
+                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item"
+                      ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item--selected': subHeaderCtrl.isSelectedSuggested('general', suggested)}"
+                            ng-click="subHeaderCtrl.adopt('general', 'Articles')"
+                            ng-repeat="suggested in subHeaderCtrl.raw_suggested.general.Articles"
+                            ng-mouseover="subHeaderCtrl.select_suggested('general', 'Articles', suggested)">
+                          {{suggested}}
+                      </div>
+                    </div>
+
+
+                    <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type" ng-show="subHeaderCtrl.suggested_distribution.general[2] > 0">
+                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title" ng-show="subHeaderCtrl.raw_suggested.general.Media.length > 0">
+                          <en>Media:</en>
+                          <he>מתחיל מ:</he>
+                      </div>
+                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item"
+                            ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item--selected': subHeaderCtrl.isSelectedSuggested('general', suggested)}"
+                            ng-click="subHeaderCtrl.adopt('general', 'Media')"
+                            ng-repeat="suggested in subHeaderCtrl.raw_suggested.general.Media"
+                            ng-mouseover="subHeaderCtrl.select_suggested('general', 'Media', suggested)">
+                          {{suggested}}
+                      </div>
+                    </div>
+
+
                   </div>
                 </div>
               </div>
+
 				    	<button class="search-button-back" ng-click="subHeaderCtrl.search()" ng-disabled="subHeaderCtrl.header.query.length < 2">
 			    			<icon  class="button" alt-text="{en: 'Search Databases', he: 'חיפש במאגרים'}" position="[-168, -426]"></icon>
 				    	</button>

--- a/templates/main/sub-header.html
+++ b/templates/main/sub-header.html
@@ -15,9 +15,52 @@
 				    	<input  id="search-input"
 				    			ng-model="subHeaderCtrl.header.query"
 				    			autofocus
-				    			ng-keydown="subHeaderCtrl.search_on_enter($event)"
+                  ng-change="subHeaderCtrl.get_suggestions('general')"
+                  ng-focus="subHeaderCtrl.open_suggested('general')"
+                  ng-blur="subHeaderCtrl.close_suggested('general')"
+
+                  ng-keydown="subHeaderCtrl.handle_keyboard($event, 'general')"
 				    			type="text"
 				    			placeholder="{{(lang=='en')?'Continue to explore...':'להמשיך לחקור...'}}">
+              <div class="wizard-form__field__autosuggest-wrapper">
+                <div class="wizard-form__field__autosuggest-wrapper__autosuggest" ng-show="subHeaderCtrl.suggested_open['general']">
+                  <div class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper">
+
+                    <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type"
+                        ng-show="subHeaderCtrl.suggested_distribution.general[0] > 0">
+                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title"
+                          ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title--selected': subHeaderCtrl.get_active_title('general') === 0}">
+                          <en>Exact Match:</en>
+                          <he>התאמה מלאה:</he>
+                      </div>
+                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item"
+                          ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item--selected': subHeaderCtrl.isSelectedSuggested('general', suggested)}"
+                          ng-click="subHeaderCtrl.adopt('name')"
+                          ng-mouseover="subHeaderCtrl.select_suggested('general', suggested)"
+                          ng-repeat="suggested in subHeaderCtrl.raw_suggested.general.exact track by $index">
+                          {{suggested}}
+                      </div>
+                    </div>
+
+
+                    <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type"
+                        ng-show="subHeaderCtrl.suggested_distribution.general[1] > 0">
+                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title"
+                          ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title--selected': subHeaderCtrl.get_active_title('general') === 1}">
+                          <en>Starts With:</en>
+                          <he>מתחיל מ:</he>
+                      </div>
+                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item"
+                          ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item--selected': subHeaderCtrl.isSelectedSuggested('general', suggested)}"
+                          ng-click="subHeaderCtrl.adopt('general')"
+                          ng-mouseover="subHeaderCtrl.select_suggested('general', suggested)"
+                          ng-repeat="suggested in subHeaderCtrl.raw_suggested.general.starts_with | limitTo: 5 track by $index">
+                          {{suggested}}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
 				    	<button class="search-button-back" ng-click="subHeaderCtrl.search()" ng-disabled="subHeaderCtrl.header.query.length < 2">
 			    			<icon  class="button" alt-text="{en: 'Search Databases', he: 'חיפש במאגרים'}" position="[-168, -426]"></icon>
 				    	</button>


### PR DESCRIPTION
### changelog
issue #279 
As the user is starting to type a search term in General Search input field, the dropdown displaying suggestions from all DBs opens.
Currently the backend returns up to 7 results for each collection, out of the following collections: personalities, places, persons, movies, photoUnits, familyNames.
All suggestions were sorted by 3 main categories: People (persons, personalities), Articles (places, familyNames) and Media (photoUnits), then sorted alphabetically.
Duplicates under same category were deleted.
Each category displays up to 6 suggestions.

### affected components
* general search box
* wizard search box

### risks
* wizard search and general search share the same service that brings suggestions. check both search boxes

### follow-up issues
* no follow-up - everything works according to spec
