### PR TITLE
Add one new link to footer instead of images and video

### DIFF
--- a/templates/main/allresults.html
+++ b/templates/main/allresults.html
@@ -90,37 +90,7 @@
                 </div>
             </div>
             <!--To do: use 'ng-switch-when-separator="|"' -->
-            <div class="about_center" ng-switch-when="images">
-                <div class="article">
-                    <h3 class="article_title">
-                        <en>About Bernard H. and Miriam Oster Visual Documentation Center</en>
-                        <he>אודות מרכז לתיעוד חזותי ע"ש ברנרד ה. ומרים אוסטר בבית התפוצות</he>
-                    </h3>
-                    <div class="content">
-                        <en>
-                            <p>If a picture paints a thousand words, then the Bernard H. and Miriam Oster Visual Documentation Center of Beit Hatfutsot speaks countless volumes.</p>
-                            <p>Indeed, the Center is one of the richest and most diverse collections of photographs depicting Jewish history, heritage, creativity and communal life, and over 800 rare films and self-produced documentaries about Jewish life
-                                across the globe.</p>
-                            <p>The Center constitutes an internationally recognized center of Jewish documentation. It is a valuable resource for scholars, publishers, journalists, the media, institutions and members of the general public who are interested
-                                in Jewish culture, history and communal life.</p>
-                            <p>The visual documentation collections cover a vast array of Jewish life, including: communities, synagogues, public institutions, culture, art, holidays, ceremonies, family and home life, lifestyles, trades, professions, key
-                                personalities and events.</p>
-                            <p>To receive more information about the photo and video collections, or to donate photographs, prints, slides, or films, please contact the Bernard H. and Miriam Oster Visual Documentation Center at rachels@bh.org.il or tel:
-                                972-3-7457851.
-                            </p>
-                        </en>
-                        <he>
-                            <p>המרכז לתיעוד חזותי ע"ש ברנרד ה. ומרים אוסטר בבית התפוצות הוא בית לאוסף התמונות וסרטים, מהעשירים בעולם היהודי.</p>
-                            <p>התמונות במרכז מתארות את ההיסטוריה, המורשת, היצירה וחיי הקהילה היהודית, ומכסות תחומי חיים נרחבים, בהם קהילות, בתי כנסת, מוסדות ציבור, תרבות ואמנות, חגים וטקסים, חיי משפחה וחיי יום-יום, סגנונות ואורחות חיים, מקצועות ועיסוקים,
-                                אישים ואירועים. עוד במרכז אוסף של יותר מ-800 סרטים, רבים נדירים, חלקם סרטים תיעודיים שהופקו על ידי בית התפוצות.</p>
-                            <p>המרכז משרת לא רק את הקהל הרחב, אלא גם חוקרים, מוציאים לאור, עיתונאים, כלי תקשורת ומוסדות מקצועיים נוספים ברחבי העולם.</p>
-                            <p>לקבלת מידע נוסף על אוספי התמונות והסרטים, לאפשרויות רכישה באיכות גבוהה, או לתרומה של תמונות, הדפסים, שקופיות או סרטים, אנא צרו קשר:</p>
-                            <p>מייל: rachels@bh.org.il<br>טלפון: 03-7457850</p>
-                        </he>
-                    </div>
-                </div>
-            </div>
-            <div class="about_center" ng-switch-when="videos">
+            <div class="about_center" ng-switch-when="visual_documentation">
                 <div class="article">
                     <h3 class="article_title">
                         <en>About Bernard H. and Miriam Oster Visual Documentation Center</en>

--- a/templates/main/footer.html
+++ b/templates/main/footer.html
@@ -11,16 +11,14 @@
 					<a ng-click="headerController.goto_about_collection('about_center', 'familyNames')">Family Names</a>
 					<a ng-click="headerController.goto_about_collection('about_center', 'places')">Jewish Communities</a>
 					<!-- <a>Jewish Music</a> -->
-					<a ng-click="headerController.goto_about_collection('about_center', 'images')">Images</a>
-          <a ng-click="headerController.goto_about_collection('about_center', 'videos')">Video</a>
+					<a ng-click="headerController.goto_about_collection('about_center', 'visual_documentation')">Visual Documentation</a>
 				</en>
 				<he>
 					<a ng-click="headerController.goto_about_collection('he.he_about_center', 'familyTree')">גניאולוגיה יהודית</a>
 					<a ng-click="headerController.goto_about_collection('he.he_about_center', 'familyNames')">שמות משפחה</a>
 					<a ng-click="headerController.goto_about_collection('he.he_about_center', 'places')">קהילות יהודיות</a>
 					<!-- <a>מוזיקה יהודית</a> -->
-					<a ng-click="headerController.goto_about_collection('he.he_about_center', 'images')">תמונות</a>
-          <a ng-click="headerController.goto_about_collection('he.he_about_center', 'videos')">וידאו</a>
+					<a ng-click="headerController.goto_about_collection('he.he_about_center', 'visual_documentation')">תיעוד חזותי</a>
 				</he>
 			</div>
 			<div class="contact-rights">


### PR DESCRIPTION
see #371 
- Changed links on _footer.html_: instead of 'Images' and 'Videos' there should be one link: 'Visual Documentation'. 
- The text was originally identical, so the only change in _allresults.html_ is the value of ng-switch ('visual_documentation' instead of 'images' and 'videos'), and deletion of the unused (identical) text.