### PR TITLE
some General Search suggestions fixes

### DIFF
--- a/js/modules/main/src/controllers/subHeaderController.js
+++ b/js/modules/main/src/controllers/subHeaderController.js
@@ -24,8 +24,8 @@ var SubHeaderController = function($state, header, suggest, $timeout) {
         get: function() {
             return {
                 general: [
-                    suggest.suggested.general.People.length,
                     suggest.suggested.general.Articles.length,
+                    suggest.suggested.general.People.length,
                     suggest.suggested.general.Media.length
                 ]
             }
@@ -34,8 +34,8 @@ var SubHeaderController = function($state, header, suggest, $timeout) {
 
     Object.defineProperty(this.suggested, 'general', {
         get: function() {
-            return suggest.suggested.general.People.
-                concat(suggest.suggested.general.Articles.
+            return suggest.suggested.general.Articles.
+                concat(suggest.suggested.general.People.
                     concat(suggest.suggested.general.Media));
         }
     });

--- a/templates/main/sub-header.html
+++ b/templates/main/sub-header.html
@@ -25,24 +25,11 @@
               <div class="wizard-form__field__autosuggest-wrapper">
                 <div class="wizard-form__field__autosuggest-wrapper__autosuggest" ng-show="subHeaderCtrl.suggested_open['general']">
                   <div class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper">
-                    <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type" ng-show="subHeaderCtrl.suggested_distribution.general[0] > 0">
-                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title">
-                          <en>People:</en>
-                          <he>מתחיל מ:</he>
-                      </div>
-                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item"
-                            ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item--selected': subHeaderCtrl.isSelectedSuggested('general', suggested)}"
-                            ng-click="subHeaderCtrl.adopt('general', 'People')"
-                            ng-repeat="suggested in subHeaderCtrl.raw_suggested.general.People"
-                            ng-mouseover="subHeaderCtrl.select_suggested('general', 'People', suggested)">
-                          {{suggested}}
-                      </div>
-                    </div>
 
                     <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type" ng-show="subHeaderCtrl.suggested_distribution.general[1] > 0">
                       <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title" ng-show="subHeaderCtrl.raw_suggested.general.Articles.length > 0">
                           <en>Articles:</en>
-                          <he>מתחיל מ:</he>
+                          <he>מידע:</he>
                       </div>
                       <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item"
                       ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item--selected': subHeaderCtrl.isSelectedSuggested('general', suggested)}"
@@ -52,12 +39,23 @@
                           {{suggested}}
                       </div>
                     </div>
-
-
+                    <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type" ng-show="subHeaderCtrl.suggested_distribution.general[0] > 0">
+                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title">
+                          <en>People:</en>
+                          <he>אנשים:</he>
+                      </div>
+                      <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item"
+                            ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item--selected': subHeaderCtrl.isSelectedSuggested('general', suggested)}"
+                            ng-click="subHeaderCtrl.adopt('general', 'People')"
+                            ng-repeat="suggested in subHeaderCtrl.raw_suggested.general.People"
+                            ng-mouseover="subHeaderCtrl.select_suggested('general', 'People', suggested)">
+                          {{suggested}}
+                      </div>
+                    </div>
                     <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type" ng-show="subHeaderCtrl.suggested_distribution.general[2] > 0">
                       <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title" ng-show="subHeaderCtrl.raw_suggested.general.Media.length > 0">
                           <en>Media:</en>
-                          <he>מתחיל מ:</he>
+                          <he>מדיה:</he>
                       </div>
                       <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item"
                             ng-class="{'wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__item--selected': subHeaderCtrl.isSelectedSuggested('general', suggested)}"

--- a/templates/main/sub-header.html
+++ b/templates/main/sub-header.html
@@ -7,6 +7,8 @@
 		<div class="border-adhoc">
 			<ng-switch on="subHeaderCtrl.header.sub_header_state">
 				<div ng-switch-when="general-search" class="general-search" ng-show="subHeaderCtrl.header.sub_header_state == 'general-search'">
+          <form id="general_search_form" autocomplete="off">
+
 					<label for="search-input" class="search-button-label">
 			        	<en>Search: </en>
 			        	<he>חיפוש כללי: </he>
@@ -26,7 +28,7 @@
                 <div class="wizard-form__field__autosuggest-wrapper__autosuggest" ng-show="subHeaderCtrl.suggested_open['general']">
                   <div class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper">
 
-                    <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type" ng-show="subHeaderCtrl.suggested_distribution.general[1] > 0">
+                    <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type" ng-show="subHeaderCtrl.suggested_distribution.general[0] > 0">
                       <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title" ng-show="subHeaderCtrl.raw_suggested.general.Articles.length > 0">
                           <en>Articles:</en>
                           <he>מידע:</he>
@@ -39,7 +41,7 @@
                           {{suggested}}
                       </div>
                     </div>
-                    <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type" ng-show="subHeaderCtrl.suggested_distribution.general[0] > 0">
+                    <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type" ng-show="subHeaderCtrl.suggested_distribution.general[1] > 0">
                       <div  class="wizard-form__field__autosuggest-wrapper__autosuggest__type-wrapper__type__title">
                           <en>People:</en>
                           <he>אנשים:</he>
@@ -75,6 +77,7 @@
 			    			<icon  class="button" alt-text="{en: 'Search Databases', he: 'חיפש במאגרים'}" position="[-168, -426]"></icon>
 				    	</button>
 			    	</div>
+          </form>
 				</div>
 				<div ng-switch-when="recently-viewed" class="recently-viewed" ng-controller="RecentlyViewedController as recentlyViewedCtrl">
 					<div 	class="recently-arrow"


### PR DESCRIPTION
1. allow general search to start search with ENTER key
2. display categories in suggestions box in correct order: 'Articles', 'People', 'Media'
3. translate general search suggestions section titles to Hebrew

affected areas: General Search Suggestion box