### PR TITLE
GS should display 'persons' collection results under 'All Results' tab

### DIFF
--- a/js/modules/main/src/controllers/GeneralSearchController.js
+++ b/js/modules/main/src/controllers/GeneralSearchController.js
@@ -288,6 +288,7 @@ GeneralSearchController.prototype = {
                 this.search_params = params;
             }
         }
+        else { params.with_persons = 1; }
         params.from_ = this.results.hits.length;
         return params;
     },


### PR DESCRIPTION
issue #393 

in order to include persons results to all General Search results the 'with_persons = 1' parameter was added to search params
### affected areas:
* general search 'all results' tab
### no risks 
