### PR TITLE
Viewing person in tree from search results should work #382

### DIFF
--- a/js/modules/main/src/controllers/itemPreviewCtrl.js
+++ b/js/modules/main/src/controllers/itemPreviewCtrl.js
@@ -27,7 +27,7 @@ ItemPreviewCtrl.prototype = {
             return this.$state.href(state_name,
                                     {tree_number:item_data.tree_num,
                                     version:item_data.tree_version,
-                                    node_id: item_data.id});
+                                    node_id: item_data.person_id});
         }
         else {
 			return this.item.get_url(item_data);

--- a/js/modules/main/src/controllers/itemPreviewCtrl.js
+++ b/js/modules/main/src/controllers/itemPreviewCtrl.js
@@ -17,7 +17,6 @@ var ItemPreviewCtrl = function($state, $scope, itemTypeMap, mjs, item, langManag
 ItemPreviewCtrl.prototype = {
 
     get_item_url: function(item_data) {
-
 		// TODO: refactor to user item.get_url
         if (this.url !== undefined) {
             return this.url;
@@ -27,7 +26,8 @@ ItemPreviewCtrl.prototype = {
             return this.$state.href(state_name,
                                     {tree_number:item_data.tree_num,
                                     version:item_data.tree_version,
-                                    node_id: item_data.person_id});
+                                    node_id: (item_data.person_id||item_data.id)
+                                });
         }
         else {
 			return this.item.get_url(item_data);


### PR DESCRIPTION
old persons search and general persons search use two different 'person id' properties to build person's link for viewing person in tree:
'person_id' for general search and 'id' for the old search.
The solution to have both possible options for person id ('person_id' and 'id') and use the available one.
## affected areas
*  old persons search
* General Persons Search

## no risks

## notes:
* possible solution: use unified property name for both old persons search and General Persons Search
 