### PR TITLE
unify place search param in persons search

### DIFF
--- a/js/modules/main/src/_init/_init.js
+++ b/js/modules/main/src/_init/_init.js
@@ -105,7 +105,7 @@ function($urlRouterProvider, $stateProvider, $locationProvider, $httpProvider, $
             name: 'general-search',
             url: '/search?q&size&from_&collection'+
                         '&first&first_t&last&last_t'+
-                        '&pob&pom&pod&pob_t&pom_t&pod_t&pob_v&pom_v&pod_v'+
+                        '&place&pob&pom&pod&place_t&pob_t&pom_t&pod_t'+
                         '&yob&yom&yod&yob_t&yom_t&yod_t&yob_v&yom_v&yod_v'+
                         '&sex&treenum&more',
             controller: 'GeneralSearchController as generalSearchCtrl',
@@ -160,7 +160,7 @@ function($urlRouterProvider, $stateProvider, $locationProvider, $httpProvider, $
             name: 'he.he_general-search',
             url: '/חפשו?q&size&from_&collection'+
                         '&first&first_t&last&last_t'+
-                        '&pob&pom&pod&pob_t&pom_t&pod_t&pob_v&pom_v&pod_v'+
+                        '&place&pob&pom&pod&place_t&pob_t&pom_t&pod_t'+
                         '&yob&yom&yod&yob_t&yom_t&yod_t&yob_v&yom_v&yod_v'+
                         '&sex&treenum&more',
             controller: 'GeneralSearchController as generalSearchCtrl',

--- a/js/modules/main/src/controllers/GeneralSearchController.js
+++ b/js/modules/main/src/controllers/GeneralSearchController.js
@@ -37,6 +37,7 @@ var GeneralSearchController = function($rootScope, europeanaUrl, $scope, $state,
     this.search_modifiers  = {
         first_t: '',
         last_t: '',
+        place_t: '',
         pob_t:  '',
         pom_t:  '',
         pod_t:  '',
@@ -188,20 +189,25 @@ GeneralSearchController.prototype = {
     },
 
     toggle_more: function() {
+        var self = this;
         var param = this.$stateParams;
         if (param.more == '0' || param.more == undefined) {
             param.more = '1';
-            /*if(this.search_params.place) {
-                this.search_params.birth_place = this.search_params.place;
-                this.search_params.place = '';
-            }*/
+            if(this.search_params.place) {
+                this.search_params.pob = this.search_params.place;
+                delete this.search_params.place;
+            }
         }
         else {
             param.more = '0';
-            /*if(this.search_params.birth_place) {
-                this.search_params.place = this.search_params.birth_place;
-                this.search_params.birth_place = '';
-            }*/
+            var places = ['pob', 'pom', 'pod'];
+            for (var key in places) {
+                if (this.search_params[places[key]]) {
+                    this.search_params.place = this.search_params[places[key]];
+                    for (var key in places) {delete this.search_params[places[key]]};
+                    break;
+                }
+            }
         }
         this.$location.search(param);
     },

--- a/templates/main/search-results.html
+++ b/templates/main/search-results.html
@@ -84,7 +84,7 @@
                                     search-type = "text"
                                     label-text-en="Place of Birth / Marriage / Death"
                                     label-text-he="מקום לידה \ נישואין \ פטירה:"
-                                    model="pob"
+                                    model="place"
                                     placeholder="{{ctrl.lang == 'en'?'Tel-Aviv, Israel...':'תל-אביב, ישראל'}}">
                     </persons-field>
                 </ng-switch>


### PR DESCRIPTION
issue #411
### preconditions:
* person with different birth and death places
* for example: http://test.dbs.bh.org.il/person/5585/0/I1856
  * birth place: Russia
  * death place: US

### reproduction steps:
* open general search: http://test.dbs.bh.org.il/search
* search for the person name
* go to advanced search, filter for place of death: "US"
* go to simple search, filter again

### expected:
* in advanced search  the results should have all people who died in US
* when switching to simple search the 'place of death' and 'unified place' fields are toggled
* in simple search the results should have all people who were either born or married or died in US

### affected areas:
* general persons search form
* general persons search results area
* url (new parameters - 'place' and 'place_t')

