### PR TITLE
419 fix "Exit Tree" 

### DIFF
--- a/js/modules/main/src/controllers/itemPreviewCtrl.js
+++ b/js/modules/main/src/controllers/itemPreviewCtrl.js
@@ -1,7 +1,9 @@
-var ItemPreviewCtrl = function($state, $scope, itemTypeMap, mjs, item, langManager) {
+var ItemPreviewCtrl = function($state, $scope, $location, $rootScope, itemTypeMap, mjs, item, langManager) {
 
     var self = this;
     this.$state = $state;
+    this.$rootScope = $rootScope;
+    this.$location = $location;
     this.mjs = mjs;
     this.$scope = $scope;
     this.item = item;
@@ -15,6 +17,10 @@ var ItemPreviewCtrl = function($state, $scope, itemTypeMap, mjs, item, langManag
 };
 
 ItemPreviewCtrl.prototype = {
+
+    saveCurrentSearchUrl: function(){
+        this.$rootScope.lastSearchUrl = this.$location.url();
+    },
 
     get_item_url: function(item_data) {
 		// TODO: refactor to user item.get_url
@@ -67,4 +73,4 @@ ItemPreviewCtrl.prototype = {
 
 };
 
-angular.module('main').controller('ItemPreviewCtrl', ['$state', '$scope', 'itemTypeMap', 'mjs', 'item', 'langManager', ItemPreviewCtrl]);
+angular.module('main').controller('ItemPreviewCtrl', ['$state', '$scope', '$location', '$rootScope', 'itemTypeMap', 'mjs', 'item', 'langManager', ItemPreviewCtrl]);

--- a/js/modules/main/src/controllers/personViewController.js
+++ b/js/modules/main/src/controllers/personViewController.js
@@ -71,6 +71,11 @@ var PersonViewController = function ($http, $window, $document, $rootScope,
             self.load(toParams);
 	    }
 	});
+	
+	$scope.backToLastSearch = function() {
+		$location.path($rootScope.lastSearchUrl);
+		$rootScope.lastSearchUrl = null;
+      };
 
 	document.documentElement.addEventListener('mouseup', function (e) {
 		self.mouseUp(e)

--- a/templates/main/ftrees/person.html
+++ b/templates/main/ftrees/person.html
@@ -23,7 +23,7 @@
         <icon class="twitter-icon" position="[-305, -443]"></icon>
         <icon class="mail-icon" position="[-340, -443]"></icon>
         <mjs-widget item="ctrl.node"></mjs-widget>
-        <div class="ftree-title__back" ng-click="ctrl.$state.go('general-search', ctrl.persons_search)">
+        <div class="ftree-title__back" ng-click="backToLastSearch()">
           <icon class="ftree-title__back-icon" position="[-313, -700]"></icon>
           <h3>
             <en>Exit Tree</en>

--- a/templates/main/item-preview.html
+++ b/templates/main/item-preview.html
@@ -1,6 +1,6 @@
 <div class="{{itemPreviewController.collection_name==='genTreeIndividuals'? 'person-preview':'item-preview'}}">
   <ng-switch on="itemPreviewController.collection_name==='genTreeIndividuals'">
-    <a ng-switch-when="true" ng-href="{{itemPreviewController.get_item_url(previewData)}}">
+    <a ng-switch-when="true" ng-href="{{itemPreviewController.get_item_url(previewData)}}" ng-click="itemPreviewController.saveCurrentSearchUrl()">
       <div class="top">
           <div class="tree-num">
               <div class="tree-num__title">


### PR DESCRIPTION
After viewing a family tree, "Exit tree" should lead back to your latest search results, from before entering tree view item page.

(TODO: return to the same position on search results page.)

See #419 
